### PR TITLE
Fix zsync updates

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,7 @@ P_NAME=$(echo $P_URL | cut -d/ -f5)
 P_VERSION=$(echo $P_URL | cut -d/ -f8)
 P_VERSION_NUM="${P_VERSION:1}"
 P_FILENAME=$(echo $P_URL | cut -d/ -f9)
+P_ARCH=x86_64
 WORKDIR="workdir"
 
 #=========================
@@ -80,7 +81,7 @@ cp resource/* $WORKDIR
 
 ./appimagetool.AppImage --appimage-extract
 
-export ARCH=x86_64; squashfs-root/AppRun -v $WORKDIR -u 'gh-releases-zsync|ferion11|${P_NAME}_Appimage|continuous|${P_NAME}-${P_VERSION}-*arch*.AppImage.zsync' ${P_NAME}-${P_VERSION}-${ARCH}.AppImage
+squashfs-root/AppRun -v $WORKDIR -u 'gh-releases-zsync|ferion11|${P_NAME}_Appimage|continuous|${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage.zsync' ${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage
 
 rm -rf appimagetool.AppImage
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -81,7 +81,7 @@ cp resource/* $WORKDIR
 
 ./appimagetool.AppImage --appimage-extract
 
-squashfs-root/AppRun -v $WORKDIR -u 'gh-releases-zsync|ferion11|${P_NAME}_Appimage|continuous|${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage.zsync' ${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage
+ARCH="${P_ARCH}" squashfs-root/AppRun -v $WORKDIR -u 'gh-releases-zsync|ferion11|${P_NAME}_Appimage|continuous|${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage.zsync' ${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage
 
 rm -rf appimagetool.AppImage
 


### PR DESCRIPTION
Embedded update information was broken, due to setting a wrong URL when packaging the AppImage. Fix it. Also, rename`${ARCH}` into `${P_ARCH}`, and move it atop among the related variables (e.g. `${P_NAME}`).

Should close #2 as well.