### PR TITLE
Add Atom Package Manager support in Atom terminal

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -57,6 +57,7 @@ chmod +x appimagetool.AppImage
 
 cat > "AppRun" << EOF
 #!/bin/bash
+
 HERE="\$(dirname "\$(readlink -f "\${0}")")"
 #------------------------------
 
@@ -70,6 +71,9 @@ export LD_LIBRARY_PATH="\$HERE/atom-${P_VERSION_NUM}-amd64":\$LD_LIBRARY_PATH
 MAIN="\$HERE/atom-${P_VERSION_NUM}-amd64/atom"
 
 export PATH=\$HERE/atom-${P_VERSION_NUM}-amd64:\$PATH
+# Detect APM (Atom Package Manager)
+export PATH="\$HERE/atom-${P_VERSION_NUM}-amd64/resources/app/apm/bin":"\$PATH"
+
 "\$MAIN" "\$@" | cat
 
 EOF


### PR DESCRIPTION
`apm` command could not found when Atom is opened. Add its path to `AppRun` file.