### PR TITLE
Code cleanup and improvements, including separation of AppRun file

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-HERE="\$(dirname "\$(readlink -f "\${0}")")"
+HERE="$(dirname "$(readlink -f "${0}")")"
 
 # Libs and deps variables
-export LD_LIBRARY_PATH="\$HERE/atom-${P_VERSION_NUM}-amd64":\$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="$HERE/atom":"$LD_LIBRARY_PATH"
 
 # from .desktop
 #export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=false
 
-export PATH=\$HERE/atom-${P_VERSION_NUM}-amd64:\$PATH
+export PATH="$HERE/atom":"$PATH"
 # Detect APM (Atom Package Manager)
-export PATH="\$HERE/atom-${P_VERSION_NUM}-amd64/resources/app/apm/bin":"\$PATH"
+export PATH="$HERE/atom/resources/app/apm/bin":"$PATH"
 
-MAIN="\$HERE/atom-${P_VERSION_NUM}-amd64/atom"
-"\$MAIN" "\$@" | cat
+MAIN="$HERE/atom/atom"
+"$MAIN" "$@" | cat

--- a/AppRun
+++ b/AppRun
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+HERE="\$(dirname "\$(readlink -f "\${0}")")"
+
+# Libs and deps variables
+export LD_LIBRARY_PATH="\$HERE/atom-${P_VERSION_NUM}-amd64":\$LD_LIBRARY_PATH
+
+# from .desktop
+#export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=false
+
+export PATH=\$HERE/atom-${P_VERSION_NUM}-amd64:\$PATH
+# Detect APM (Atom Package Manager)
+export PATH="\$HERE/atom-${P_VERSION_NUM}-amd64/resources/app/apm/bin":"\$PATH"
+
+MAIN="\$HERE/atom-${P_VERSION_NUM}-amd64/atom"
+"\$MAIN" "\$@" | cat

--- a/AppRun
+++ b/AppRun
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 HERE="$(dirname "$(readlink -f "${0}")")"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,35 +8,28 @@ P_FILENAME=$(echo $P_URL | cut -d/ -f9)
 P_ARCH=x86_64
 WORKDIR="workdir"
 
-die() { echo >&2 "$*"; exit 1; };
-
 sudo apt update
 sudo apt install -y aptitude wget file bzip2
 
 mkdir "$WORKDIR"
 
-wget -nv $P_URL
-tar xf $P_FILENAME -C "$WORKDIR/"
+# Download and extract the archive file
+wget -nv "$P_URL"
+tar xf "$P_FILENAME" -C "$WORKDIR/"
 
-cd "$WORKDIR" || die "ERROR: Directory don't exist: $WORKDIR"
+# AppRun file supposes main directory to be named 'atom'
+mv "$WORKDIR/atom-{$P_VERSION}-amd64" "$WORKDIR/atom"
 
-pkgcachedir='/tmp/.pkgdeploycache'
-mkdir -p $pkgcachedir
-
-cd ..
-
-wget -nv -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O  appimagetool.AppImage
+wget -nv -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O appimagetool.AppImage
 chmod +x appimagetool.AppImage
 
 chmod +x AppRun
 
-cp AppRun $WORKDIR
-cp resource/* $WORKDIR
+cp AppRun "$WORKDIR"
+cp resource/* "$WORKDIR"
 
-./appimagetool.AppImage --appimage-extract
+ARCH="${P_ARCH}" ./appimagetoo.AppImage -v "$WORKDIR" -u 'gh-releases-zsync|ferion11|${P_NAME}_Appimage|continuous|${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage.zsync' "${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage"
 
-ARCH="${P_ARCH}" squashfs-root/AppRun -v $WORKDIR -u 'gh-releases-zsync|ferion11|${P_NAME}_Appimage|continuous|${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage.zsync' ${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage
-
-rm -rf appimagetool.AppImage
+rm appimagetool.AppImage
 
 echo "All files at the end of script: $(ls)"

--- a/deploy.sh
+++ b/deploy.sh
@@ -56,28 +56,6 @@ cd ..
 wget -nv -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O  appimagetool.AppImage
 chmod +x appimagetool.AppImage
 
-cat > "AppRun" << EOF
-#!/bin/bash
-
-HERE="\$(dirname "\$(readlink -f "\${0}")")"
-#------------------------------
-
-# Libs and deps variables
-export LD_LIBRARY_PATH="\$HERE/atom-${P_VERSION_NUM}-amd64":\$LD_LIBRARY_PATH
-
-# from .desktop
-#export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=false
-
-#------------------------------
-MAIN="\$HERE/atom-${P_VERSION_NUM}-amd64/atom"
-
-export PATH=\$HERE/atom-${P_VERSION_NUM}-amd64:\$PATH
-# Detect APM (Atom Package Manager)
-export PATH="\$HERE/atom-${P_VERSION_NUM}-amd64/resources/app/apm/bin":"\$PATH"
-
-"\$MAIN" "\$@" | cat
-
-EOF
 chmod +x AppRun
 
 cp AppRun $WORKDIR

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 P_URL="https://github.com/atom/atom/releases/download/v1.58.0/atom-amd64.tar.gz"
 P_NAME=$(echo $P_URL | cut -d/ -f5)
 P_VERSION=$(echo $P_URL | cut -d/ -f8)
@@ -7,20 +8,11 @@ P_FILENAME=$(echo $P_URL | cut -d/ -f9)
 P_ARCH=x86_64
 WORKDIR="workdir"
 
-#=========================
 die() { echo >&2 "$*"; exit 1; };
-#=========================
 
-#add-apt-repository ppa:webupd8team/atom -y
-
-#-----------------------------
-#dpkg --add-architecture i386
 sudo apt update
-#apt install -y aptitude wget file bzip2 gcc-multilib
 sudo apt install -y aptitude wget file bzip2
-#===========================================================================================
-# Get inex
-# using the package
+
 mkdir "$WORKDIR"
 
 wget -nv $P_URL
@@ -31,26 +23,6 @@ cd "$WORKDIR" || die "ERROR: Directory don't exist: $WORKDIR"
 pkgcachedir='/tmp/.pkgdeploycache'
 mkdir -p $pkgcachedir
 
-#sudo aptitude -y -d -o dir::cache::archives="$pkgcachedir" install atom
-# sudo chmod 777 $pkgcachedir -R
-
-#extras
-#wget -nv -c http://ftp.osuosl.org/pub/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-4_amd64.deb -P $pkgcachedir
-
-#find $pkgcachedir -name '*deb' ! -name 'mesa*' -exec dpkg -x {} . \;
-#echo "All files in $pkgcachedir: $(ls $pkgcachedir)"
-#---------------------------------
-
-##clean some packages to use natives ones:
-#rm -rf $pkgcachedir ; rm -rf share/man ; rm -rf usr/share/doc ; rm -rf usr/share/lintian ; rm -rf var ; rm -rf sbin ; rm -rf usr/share/man
-#rm -rf usr/share/mime ; rm -rf usr/share/pkgconfig; rm -rf lib; rm -rf etc;
-#---------------------------------
-#===========================================================================================
-
-##fix something here:
-
-#===========================================================================================
-# appimage
 cd ..
 
 wget -nv -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O  appimagetool.AppImage

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,7 +28,7 @@ chmod +x AppRun
 cp AppRun "$WORKDIR"
 cp resource/* "$WORKDIR"
 
-ARCH="${P_ARCH}" ./appimagetoo.AppImage -v "$WORKDIR" -u 'gh-releases-zsync|ferion11|${P_NAME}_Appimage|continuous|${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage.zsync' "${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage"
+ARCH="${P_ARCH}" ./appimagetool.AppImage -v "$WORKDIR" -u 'gh-releases-zsync|ferion11|atom_Appimage|continuous-master|${P_NAME}-*-${P_ARCH}.AppImage.zsync' "${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage"
 
 rm appimagetool.AppImage
 


### PR DESCRIPTION
Move AppRun contents into a new `AppRun` file. For preserving forward-compatibility of future builds, the file supposes the Atom directory to be named `atom`, instead of `atom-<version>-amd64`, and `deploy.sh` makes this move just before moving `AppRun` to the workdir.

Remove a bunch of commented code. For possible future references, `git log` should be our friend.

This one should also fix #2 (finally?). :)