### PR TITLE
Fix build, fix zsync updates

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -28,7 +28,7 @@ chmod +x AppRun
 cp AppRun "$WORKDIR"
 cp resource/* "$WORKDIR"
 
-ARCH="${P_ARCH}" ./appimagetool.AppImage -v "$WORKDIR" -u 'gh-releases-zsync|ferion11|atom_Appimage|continuous-master|${P_NAME}-*-${P_ARCH}.AppImage.zsync' "${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage"
+ARCH="${P_ARCH}" ./appimagetool.AppImage -v "$WORKDIR" -u "gh-releases-zsync|ferion11|atom_Appimage|continuous-master|${P_NAME}-*-${P_ARCH}.AppImage.zsync" "${P_NAME}-${P_VERSION}-${P_ARCH}.AppImage"
 
 rm appimagetool.AppImage
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,7 +18,7 @@ wget -nv "$P_URL"
 tar xf "$P_FILENAME" -C "$WORKDIR/"
 
 # AppRun file supposes main directory to be named 'atom'
-mv "$WORKDIR/atom-{$P_VERSION}-amd64" "$WORKDIR/atom"
+mv "$WORKDIR/atom-{$P_VERSION_NUM}-amd64" "$WORKDIR/atom"
 
 wget -nv -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" -O appimagetool.AppImage
 chmod +x appimagetool.AppImage


### PR DESCRIPTION
Due to a wrong variable name in `deploy.sh` build script, the built AppImage does not work. This PR fixes that.

Also, the embedded update information is fixed. There were two PRs previously targeting this one, but failed and the fixes were partial. The difference between this one and the previous ones is that, I tested this one, and the AppImage updated perfectly.